### PR TITLE
Update GitHub Actions workflow branch trigger

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Auto Tag and Release
 on:
   push:
     branches:
-      - main-sylent-sys
+      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Change the GitHub Actions workflow to trigger on the main branch instead of the previous main-sylent-sys branch.