### PR TITLE
Update GitHub Actions workflow container to archlinux:latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
   build-and-release:
     needs: auto-tag
     runs-on: ubuntu-latest
-    container: archlinux/base:latest
+    container: archlinux:latest
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4


### PR DESCRIPTION
Change the container used in the GitHub Actions workflow to the latest Arch Linux version for improved compatibility and performance.