### PR TITLE
Add tag existence check to GitHub Actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,12 @@ jobs:
         run: |
           DATE_TAG=$(date -u +"%Y.%m.%d")
           echo "tag=$DATE_TAG" >> $GITHUB_OUTPUT
+      - name: Skip Existing Tag
+        run: |
+          if git ls-remote --tags origin ${{ steps.tag.outputs.tag }} | grep -q "${{ steps.tag.outputs.tag }}"; then
+            echo "Tag sudah ada, skip build."
+            exit 1
+          fi
       - name: Create Git Tag
         uses: actions/github-script@v6
         with:
@@ -42,9 +48,7 @@ jobs:
           mkarchiso -v -w ./work -o ./build ./releng
           mv ./build/*.iso ./imphnenos.iso
       - name: Publish Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.auto-tag.outputs }}
           files: imphnenos.iso
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Implement a check in the GitHub Actions workflow to skip the build process if the tag already exists, and update the action version used for publishing releases.